### PR TITLE
Fixed some "bugs" relating to how agents are displayed 

### DIFF
--- a/lib/game_data.js
+++ b/lib/game_data.js
@@ -250,6 +250,11 @@ class GameData {
         }
         else iteminfo['max'] = 0.8;
 
+        if (iteminfo.floatvalue == 0) {
+            iteminfo['max'] = 0;
+            iteminfo['min'] = 0;
+        }
+
         let weapon_data = '';
 
         if (iteminfo.defindex in this.items_game['items']) {

--- a/lib/game_data.js
+++ b/lib/game_data.js
@@ -263,14 +263,19 @@ class GameData {
 
         // Get the weapon_hud
         let weapon_hud;
+        let prefab_val = this.items_game['items'][iteminfo.defindex]['prefab'];
 
         if (weapon_data !== '' && 'item_name' in weapon_data) {
-            weapon_hud = weapon_data['item_name'].replace('#', '');
+            if (prefab_val == 'customplayertradable' || prefab_val == 'customplayer') {
+                weapon_hud = this.items_game['prefabs']['customplayer']['item_type_name'].replace('#', '');
+            }
+            else {
+                weapon_hud = weapon_data['item_name'].replace('#', '');
+            }
         }
         else {
             // need to find the weapon hud from the prefab
             if (iteminfo.defindex in this.items_game['items']) {
-                let prefab_val = this.items_game['items'][iteminfo.defindex]['prefab'];
                 weapon_hud = this.items_game['prefabs'][prefab_val]['item_name'].replace('#', '');
             }
         }


### PR DESCRIPTION
Items that did not have float values, display min and max float values.
When inspecting an agent, the weapon_type was the full agent name, instead of identifying that it's just an agent.

link: steam://rungame/730/76561202255233023/+csgo_econ_action_preview%20M663826331106610031A43192124620D5108495161639654660

Old
``` json
{
  "iteminfo": {
    "stickers": [],
    "keychains": [],
    "itemid": "43192124620",
    "defindex": 5308,
    "paintindex": 0,
    "rarity": 6,
    "quality": 4,
    "paintseed": 0,
    "inventory": 16,
    "origin": 23,
    "s": "0",
    "a": "43192124620",
    "d": "5108495161639654660",
    "m": "663826331106610031",
    "floatvalue": 0,
    "min": 0.06,
    "max": 0.8,
    "weapon_type": "Special Agent Ava | FBI",
    "item_name": "-",
    "rarity_name": "Extraordinary",
    "quality_name": "Unique",
    "origin_name": "Quest Reward",
    "full_item_name": "Special Agent Ava | FBI"
  }
}
```

New
``` json
{
  "iteminfo": {
    "stickers": [],
    "keychains": [],
    "itemid": "43192124620",
    "defindex": 5308,
    "paintindex": 0,
    "rarity": 6,
    "quality": 4,
    "paintseed": 0,
    "inventory": 16,
    "origin": 23,
    "s": "0",
    "a": "43192124620",
    "d": "5108495161639654660",
    "m": "663826331106610031",
    "floatvalue": 0,
    "min": 0,
    "max": 0,
    "weapon_type": "Agent",
    "item_name": "-",
    "rarity_name": "Extraordinary",
    "quality_name": "Unique",
    "origin_name": "Quest Reward",
    "full_item_name": "Agent"
  }
}
```